### PR TITLE
make STPopupContainerViewController public

### DIFF
--- a/STPopup/STPopupController.h
+++ b/STPopup/STPopupController.h
@@ -19,6 +19,10 @@ typedef NS_ENUM(NSUInteger, STPopupTransitionStyle) {
     STPopupTransitionStyleFade
 };
 
+@interface STPopupContainerViewController : UIViewController
+
+@end
+
 @interface STPopupController : NSObject
 
 @property (nonatomic, assign) STPopupStyle style;

--- a/STPopup/STPopupController.m
+++ b/STPopup/STPopupController.m
@@ -16,10 +16,6 @@ CGFloat const STPopupBottomSheetExtraHeight = 80;
 
 static NSMutableSet *_retainedPopupControllers;
 
-@interface STPopupContainerViewController : UIViewController
-
-@end
-
 @implementation STPopupContainerViewController
 
 - (UIStatusBarStyle)preferredStatusBarStyle


### PR DESCRIPTION
It’s necessary to make the popup container view controller public when we have to know the top-most view controller.

Without this, we should check the dynamic type of class which is less reliable.