### PR TITLE
nervier高度   使用 sizeThatFits。兼容系统的navibar高度设置

### DIFF
--- a/STPopup/STPopupController.m
+++ b/STPopup/STPopupController.m
@@ -486,8 +486,8 @@ static NSMutableSet *_retainedPopupControllers;
 {
     // The preferred height of navigation bar is different between iPhone (4, 5, 6) and 6 Plus.
     // Create a navigation controller to get the preferred height of navigation bar.
-    UINavigationController *navigationController = [UINavigationController new];
-    return navigationController.navigationBar.bounds.size.height;
+    
+    return [_navigationBar sizeThatFits:CGSizeZero].height;
 }
 
 #pragma mark - UI setup


### PR DESCRIPTION
1navibar 的高度是被sizeThatFits这个函数决定的，所以 在此新建一个bar来获取高度，不如直接用sizeThatFits获取。          2 后期如果给navibar 分类添加customBarheight属性，可以 给不同的bar设置不同的高度。navibar的高度 无论苹果的 还是自己继承的子类，都会走 sizeThatFits。所以使用这个函数会更合适