### PR TITLE
Define completion block property to be automatically executed when dismissed

### DIFF
--- a/STPopup/STPopupController.h
+++ b/STPopup/STPopupController.h
@@ -29,6 +29,8 @@ typedef NS_ENUM(NSUInteger, STPopupTransitionStyle) {
 @property (nonatomic, strong) UIView *backgroundView;
 @property (nonatomic, assign, readonly) BOOL presented;
 
+@property (nonatomic, strong) (void (^)(void))completion;
+
 - (instancetype)initWithRootViewController:(UIViewController *)rootViewController;
 
 - (void)presentInViewController:(UIViewController *)viewController;

--- a/STPopup/STPopupController.m
+++ b/STPopup/STPopupController.m
@@ -227,7 +227,11 @@ static NSMutableSet *_retainedPopupControllers;
 
 - (void)dismiss
 {
-    [self dismissWithCompletion:nil];
+    if (self.completion) {
+        [self dismissWithCompletion:self.completion];
+    } else {
+        [self dismissWithCompletion:nil];
+    }
 }
 
 - (void)dismissWithCompletion:(void (^)(void))completion


### PR DESCRIPTION
Adding a completion block to execute as a callback when STPopupController is dismissed.