### PR TITLE
Added 'presentingViewController' property

### DIFF
--- a/STPopup/STPopupController.h
+++ b/STPopup/STPopupController.h
@@ -125,4 +125,9 @@ typedef NS_ENUM(NSUInteger, STPopupTransitionStyle) {
  */
 - (void)setNavigationBarHidden:(BOOL)navigationBarHidden animated:(BOOL)animated;
 
+/**
+ The view controller that presented the popup.
+ */
+- (UIViewController *)presentingViewController;
+
 @end

--- a/STPopup/STPopupController.h
+++ b/STPopup/STPopupController.h
@@ -79,6 +79,11 @@ typedef NS_ENUM(NSUInteger, STPopupTransitionStyle) {
 @property (nonatomic, assign, readonly) BOOL presented;
 
 /**
+ The view controller that presented the popup.
+ */
+@property (nonatomic, readonly) UIViewController *presentingViewController;
+
+/**
  Init the popup with root view controller.
  */
 - (instancetype)initWithRootViewController:(UIViewController *)rootViewController;
@@ -124,10 +129,5 @@ typedef NS_ENUM(NSUInteger, STPopupTransitionStyle) {
  @see navigationBarHidden
  */
 - (void)setNavigationBarHidden:(BOOL)navigationBarHidden animated:(BOOL)animated;
-
-/**
- The view controller that presented the popup.
- */
-- (UIViewController *)presentingViewController;
 
 @end

--- a/STPopup/STPopupController.m
+++ b/STPopup/STPopupController.m
@@ -138,6 +138,11 @@ static NSMutableSet *_retainedPopupControllers;
     return _containerViewController.presentingViewController != nil;
 }
 
+- (UIViewController *)presentingViewController
+{
+    return _containerViewController.presentingViewController;
+}
+
 - (void)setBackgroundView:(UIView *)backgroundView
 {
     [_backgroundView removeFromSuperview];


### PR DESCRIPTION
Added a read-only computed property to get the `presentingViewController`. This helps further mimic `UIViewController` functionality.

The `presentingViewController` property returns `_containerViewController.presentingViewController`.