### PR TITLE
Bug Fix: UIResponder 'didEndEditing' being called twice

### DIFF
--- a/STPopup/UIResponder+STPopup.m
+++ b/STPopup/UIResponder+STPopup.m
@@ -33,7 +33,7 @@ NSString *const STPopupFirstResponderDidChangeNotification = @"STPopupFirstRespo
 - (BOOL)st_becomeFirstResponder
 {
     BOOL rs = [self st_becomeFirstResponder];
-    if ([self canBecomeFirstResponder]) {
+    if (rs) {
         [[NSNotificationCenter defaultCenter] postNotificationName:STPopupFirstResponderDidChangeNotification object:self];
     }
     return rs;


### PR DESCRIPTION
The `becomeFirstResponder` swizzled method was calling `canBecomeFirstResponder`. This triggered `UITextField`'s 'didEndEditing' delegate method to be called twice. I'm assuming this would cause similar issues with other responders, but this was the case that I observed. This fixes the problem while maintaining the same functionality.