### PR TITLE
Pass the touch event of the custom navigation bar

### DIFF
--- a/STPopup/STPopupNavigationBar.m
+++ b/STPopup/STPopupNavigationBar.m
@@ -37,10 +37,7 @@
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    if (!self.draggable) {
-        [super touchesBegan:touches withEvent:event];
-        return;
-    }
+    [super touchesBegan:touches withEvent:event];
     
     UITouch *touch = [touches anyObject];
     if ((touch.view == self || touch.view.superview == self) && !_moving) {
@@ -51,10 +48,7 @@
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    if (!self.draggable) {
-        [super touchesMoved:touches withEvent:event];
-        return;
-    }
+    [super touchesMoved:touches withEvent:event];
     
     if (_moving) {
         UITouch *touch = [touches anyObject];
@@ -67,30 +61,24 @@
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    if (!self.draggable) {
-        [super touchesCancelled:touches withEvent:event];
-        return;
-    }
-    
     if (_moving) {
         UITouch *touch = [touches anyObject];
         float offset = [touch locationInView:self.window].y - _movingStartY;
         [self movingDidEndWithOffset:offset];
     }
+    
+    [super touchesCancelled:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    if (!self.draggable) {
-        [super touchesEnded:touches withEvent:event];
-        return;
-    }
-    
     if (_moving) {
         UITouch *touch = [touches anyObject];
         float offset = [touch locationInView:self.window].y - _movingStartY;
         [self movingDidEndWithOffset:offset];
     }
+    
+    [super touchesEnded:touches withEvent:event];
 }
 
 - (void)movingDidEndWithOffset:(float)offset


### PR DESCRIPTION
Intercepting all the touch event when the bar is draggable has some side effect. For example is impossible to tap on the back left button in a master/detail relationship 