### PR TITLE
Check for nil viewcontroller when removing observer

### DIFF
--- a/STPopup/STPopupController.m
+++ b/STPopup/STPopupController.m
@@ -210,15 +210,19 @@ static NSMutableSet *_retainedPopupControllers;
 
 - (void)destroyObserversOfViewController:(UIViewController *)viewController
 {
-    [viewController removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentSizeInPopup))];
-    [viewController removeObserver:self forKeyPath:NSStringFromSelector(@selector(landscapeContentSizeInPopup))];
-    [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(title))];
-    [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(titleView))];
-    [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(leftBarButtonItem))];
-    [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(leftBarButtonItems))];
-    [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(rightBarButtonItem))];
-    [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(rightBarButtonItems))];
-    [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(hidesBackButton))];
+    if (viewController != nil) {
+        [viewController removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentSizeInPopup))];
+        [viewController removeObserver:self forKeyPath:NSStringFromSelector(@selector(landscapeContentSizeInPopup))];
+        if (viewController.navigationItem != nil) {
+            [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(title))];
+            [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(titleView))];
+            [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(leftBarButtonItem))];
+            [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(leftBarButtonItems))];
+            [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(rightBarButtonItem))];
+            [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(rightBarButtonItems))];
+            [viewController.navigationItem removeObserver:self forKeyPath:NSStringFromSelector(@selector(hidesBackButton))];
+        }
+    }
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context


### PR DESCRIPTION
STPopup may lose its reference to view controller, especially after memory warning, causing bad access crash.
Checking for existence of view controller before removing observer prevents the crash