### PR TITLE
Allow the popupController to be checked against nil in Swift

### DIFF
--- a/STPopup/UIViewController+STPopup.h
+++ b/STPopup/UIViewController+STPopup.h
@@ -26,6 +26,6 @@
  Popup controller which is containing the view controller.
  Will be nil if the view controller is not contained in any popup controller.
  */
-@property (nonatomic, weak, readonly) STPopupController *popupController;
+@property (nonatomic, weak, readonly, nullable) STPopupController *popupController;
 
 @end


### PR DESCRIPTION
According to the doc string, this returns `nil` if the view controller is not contained in any popup controller. Just letting Swift know that this is nullable 😊 .
