### PR TITLE
Added option to disable internal keyboard handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ DerivedData
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
 #Pods/
+
+### AppCode ###
+#
+.idea/

--- a/STPopup/STPopupController.h
+++ b/STPopup/STPopupController.h
@@ -106,6 +106,11 @@ typedef NS_ENUM(NSUInteger, STPopupTransitionStyle) {
 @property (nonatomic, assign) BOOL hidesCloseButton;
 
 /**
+ Enable or disable internal keyboard handling, default is YES.
+ */
+@property (nonatomic, assign) BOOL keyboardHandlingEnabled;
+
+/**
  Navigation bar of popup.
  @see STPopupNavigationBar
  */

--- a/STPopup/STPopupController.m
+++ b/STPopup/STPopupController.m
@@ -177,6 +177,25 @@ static NSMutableSet *_retainedPopupControllers;
     [self updateNavigationBarAniamted:NO];
 }
 
+- (void)setKeyboardHandlingEnabled:(BOOL)keyboardHandlingEnabled {
+    BOOL wasKeyboardHandlingEnabled = _keyboardHandlingEnabled;
+    _keyboardHandlingEnabled = keyboardHandlingEnabled;
+    // Only do something if the value changes
+    if (wasKeyboardHandlingEnabled != keyboardHandlingEnabled) {
+        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+        // Enable or disable the keyboard handling by subscribing or unsubscribing from keyboard notifications
+        if (wasKeyboardHandlingEnabled) {
+            [notificationCenter removeObserver:self name:UIKeyboardWillShowNotification object:nil];
+            [notificationCenter removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
+            [notificationCenter removeObserver:self name:UIKeyboardWillHideNotification object:nil];
+        } else {
+            [notificationCenter addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
+            [notificationCenter addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillChangeFrameNotification object:nil];
+            [notificationCenter addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+        }
+    }
+}
+
 #pragma mark - Observers
 
 - (void)setupObservers
@@ -192,7 +211,7 @@ static NSMutableSet *_retainedPopupControllers;
     
     // Observe orientation change
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChange) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
-    
+
     // Observe responder change
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(firstResponderDidChange) name:STPopupFirstResponderDidChangeNotification object:nil];
 }
@@ -580,6 +599,7 @@ static NSMutableSet *_retainedPopupControllers;
     
     _transitioningSlideVertical = [STPopupControllerTransitioningSlideVertical new];
     _transitioningFade = [STPopupControllerTransitioningFade new];
+    self.keyboardHandlingEnabled = YES;
 }
 
 - (void)setupBackgroundView

--- a/STPopup/STPopupController.m
+++ b/STPopup/STPopupController.m
@@ -193,11 +193,6 @@ static NSMutableSet *_retainedPopupControllers;
     // Observe orientation change
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChange) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
     
-    // Observe keyboard
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillChangeFrameNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    
     // Observe responder change
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(firstResponderDidChange) name:STPopupFirstResponderDidChangeNotification object:nil];
 }


### PR DESCRIPTION
Added a boolean which allows users to choose if they want the popup controller to handle the keyboard internally. This allows users to roll their own keyboard implementation or use this library together with other libraries that handle the keyboard such as [https://github.com/hackiftekhar/IQKeyboardManager](IQKeyboardManager).